### PR TITLE
Renaming everything to databoard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dashboard-ui
+# databoard-ui
 A tool to report and visualize vital, high-level data points about the Harvard Library Digital Repository Service (DRS)
 
 ## Technology Stack
@@ -14,7 +14,7 @@ Docker Compose
 ## Local Development Environment Setup Instructions
 
 ### 1: Clone the repository to a local directory
-```git clone git@github.com:harvard-lts/dashboard-ui.git```
+```git clone git@github.com:harvard-lts/databoard-ui.git```
 
 ### 2: Copy the cloned files into your own new project repository
 
@@ -47,7 +47,7 @@ This step is only required if additional python packages must be installed durin
 Open a shell using the exec command to access the hgl-downloader container.
 
 ```
-docker exec -it dashboard-ui bash
+docker exec -it databoard-ui bash
 ```
 
 ##### Install a new pip package

--- a/app/resources.py
+++ b/app/resources.py
@@ -6,11 +6,11 @@ import os, json
 #from . import <class> <class>
 
 def define_resources(app):
-    api = Api(app, version='1.0', title='DRS Data Dashboard', description='A tool to report and visualize vital, high-level data points about the Harvard Library Digital Repository Service (DRS)')
-    dashboard = api.namespace('/', description="A tool to report and visualize vital, high-level data points about the Harvard Library Digital Repository Service (DRS)")
+    api = Api(app, version='1.0', title='The Databoard!', description='A tool to report and visualize vital, high-level data points about the Harvard Library Digital Repository Service (DRS)')
+    databoard = api.namespace('/', description="A tool to report and visualize vital, high-level data points about the Harvard Library Digital Repository Service (DRS)")
 
     # Heartbeat/health check route
-    @dashboard.route('/version', endpoint="version", methods=['GET'])
+    @databoard.route('/version', endpoint="version", methods=['GET'])
     class Version(Resource):
         def get(self):
             version = os.environ.get('APP_VERSION', "NOT FOUND")

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -5,8 +5,8 @@ version: '3.8'
 
 services:
 
-  dashboard-ui:
-    container_name: 'dashboard-ui'
+  databoard-ui:
+    container_name: 'databoard-ui'
     build:
       context: './'
       dockerfile: 'DockerfileLocal'
@@ -18,10 +18,10 @@ services:
       - '3001:8081'
     # Join this service to a custom docker network
     networks:
-      - dashboard-net
+      - databoard-net
 
 
   # Create a custom docker network if it does not exist already
 networks:
-  dashboard-net:
-    name: dashboard-net
+  databoard-net:
+    name: databoard-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ version: '3.8'
 
 services:
 
-  dashboard-ui:
-    image: registry.lts.harvard.edu/lts/dashboard-ui:0.0.1
+  databoard-ui:
+    image: registry.lts.harvard.edu/lts/databoard-ui:0.0.1
     build:
       context: .
       dockerfile: DockerfilePub

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,6 @@
 [supervisord]
 nodaemon=true
-logfile=/home/appuser/logs/supervisord_dashboard-ui.log
+logfile=/home/appuser/logs/supervisord_databoard-ui.log
 pidfile = /tmp/supervisord.pid
 logfile_maxbytes=50MB
 logfile_backups=10
@@ -11,8 +11,8 @@ directory=/home/appuser
 user=appuser
 autostart=true
 autorestart=true
-stdout_logfile=/home/appuser/logs/supervisord_dashboard-ui_stdout.log
-stderr_logfile=/home/appuser/logs/supervisord_dashboard-ui_stderr.log
+stdout_logfile=/home/appuser/logs/supervisord_databoard-ui_stdout.log
+stderr_logfile=/home/appuser/logs/supervisord_databoard-ui_stderr.log
 stdout_logfile_maxbytes=50MB
 stderr_logfile_maxbytes=50MB
 stdout_logfile_backups=10


### PR DESCRIPTION
**Renaming everything to databoard.**
* * *

**JIRA Ticket**: [LIBDRS-7979](https://jira.huit.harvard.edu/browse/LIBDRS-7979)

# What does this Pull Request do?
Because of a domain name conflict with dashboard.lib.harvard.edu we have renamed this project to be databoard. I have changed all references of `dashboard` to be `databoard`.  This includes the docker image, which has been renamed to databoard-ui.0.0.1. It has already been deployed to the dev server and is visible here: https://databoard-dev.lib.harvard.edu/

# How should this be tested?

A description of what steps someone could take to:
* Either update the origin of your local repository (`git remote set-url origin git@github.com:harvard-lts/databoard-ui.git`) or clone the repository fresh (`git clone git@github.com:harvard-lts/databoard-ui.git`) 
* Check out and pull in this branch: `git checkout -b rename-to-databoard` `git pull origin rename-to-databoard`
* Rebuild the container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
* You should be able to get to these urls: https://localhost:3001/ https://localhost:3001/hello-world https://localhost:3001/healthcheck
* The log files in your local log folder should be named `databoard-ui...`
* You should be able to ssh into the container this way: `docker exec -it databoard-ui bash`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @awoods 