### PR TITLE
Prod data

### DIFF
--- a/app/static/js/databoard.js
+++ b/app/static/js/databoard.js
@@ -33,13 +33,31 @@ $(document).ready(function () {
   let i = data.length - 1; // last updated row
 
 
-  let owners = [];
-  let totalFiles = [];
-  let totalSize = [];
+  let largeOwners = [];
+  let largeTotalFiles = [];
+  let largeTotalSize = [];
+  let mediumOwners = [];
+  let mediumTotalFiles = [];
+  let mediumTotalSize = [];
+  let smallOwners = [];
+  let smallTotalFiles = [];
+  let smallTotalSize = [];
   for (i = 0; i < data.length; i++) {
-    owners.push(data[i]["CODE"]);
-    totalFiles.push(data[i]["Total files"]);
-    totalSize.push(data[i]["Total size"]);
+    if (parseInt(data[i]["Total files"]) >= 1000000) {
+      largeOwners.push(data[i]["Organization"]);
+      largeTotalFiles.push(data[i]["Total files"]);
+      largeTotalSize.push(data[i]["Total size"]);
+    }
+    if (parseInt(data[i]["Total files"]) >= 100000 && parseInt(data[i]["Total files"]) <= 999999) {
+      mediumOwners.push(data[i]["Organization"]);
+      mediumTotalFiles.push(data[i]["Total files"]);
+      mediumTotalSize.push(data[i]["Total size"]);
+    }
+    if (parseInt(data[i]["Total files"]) <= 100000) {
+      smallOwners.push(data[i]["Organization"]);
+      smallTotalFiles.push(data[i]["Total files"]);
+      smallTotalSize.push(data[i]["Total size"]);
+    }    
   }
 
   // Register the plugin to all charts:
@@ -50,24 +68,24 @@ $(document).ready(function () {
   });
 
 
-  // Number of files per owner (bar chart)
-  let filesPerOwnerOptions = {
+  // Large number of files per owner (bar chart)
+  let largeFilesPerOwnerOptions = {
     responsive: true,
     indexAxis: 'x',
     plugins: {
       title: {
         display: true,
-        text: "Number of files per owner",
+        text: "Number of files per owner (1,000,000+ files)",
         padding: { top: 10, bottom: 30 },
       }
     },
   };
-  let filesPerOwnerData = {
-    labels: owners,
+  let largeFilesPerOwnerData = {
+    labels: largeOwners,
     datasets: [
       {
         label: 'Total files',
-        data: totalFiles,
+        data: largeTotalFiles,
         backgroundColor: colors[0],
         datalabels: {
           align: 'end',
@@ -76,77 +94,172 @@ $(document).ready(function () {
       }
     ],
   };
-  let filesPerOwner = $("#filesPerOwner");
-  if (filesPerOwner) {
-    new Chart(filesPerOwner, {
+  let largeFilesPerOwner = $("#largeFilesPerOwner");
+  if (largeFilesPerOwner) {
+    new Chart(largeFilesPerOwner, {
       type: "bar",
-      data: filesPerOwnerData,
-      options: filesPerOwnerOptions,
+      data: largeFilesPerOwnerData,
+      options: largeFilesPerOwnerOptions,
     });
   }
 
-  let sizePerOwnerOptions = {
+  // Medium number of files per owner (bar chart)
+  let mediumFilesPerOwnerOptions = {
+    responsive: true,
+    indexAxis: 'x',
+    plugins: {
+      title: {
+        display: true,
+        text: "Number of files per owner (100,000 - 999,000 files)",
+        padding: { top: 10, bottom: 30 },
+      }
+    },
+  };
+  let mediumFilesPerOwnerData = {
+    labels: mediumOwners,
+    datasets: [
+      {
+        label: 'Total files',
+        data: mediumTotalFiles,
+        backgroundColor: colors[0],
+        datalabels: {
+          align: 'end',
+          anchor: 'end'
+        }
+      }
+    ],
+  };
+  let mediumFilesPerOwner = $("#mediumFilesPerOwner");
+  if (mediumFilesPerOwner) {
+    new Chart(mediumFilesPerOwner, {
+      type: "bar",
+      data: mediumFilesPerOwnerData,
+      options: mediumFilesPerOwnerOptions,
+    });
+  }
+
+  // Small number of files per owner (bar chart)
+  let smallFilesPerOwnerOptions = {
+    responsive: true,
+    indexAxis: 'x',
+    plugins: {
+      title: {
+        display: true,
+        text: "Number of files per owner (less than 100,000 files)",
+        padding: { top: 10, bottom: 30 },
+      }
+    },
+  };
+  let smallFilesPerOwnerData = {
+    labels: smallOwners,
+    datasets: [
+      {
+        label: 'Total files',
+        data: smallTotalFiles,
+        backgroundColor: colors[0],
+        datalabels: {
+          align: 'end',
+          anchor: 'end'
+        }
+      }
+    ],
+  };
+  let smallFilesPerOwner = $("#smallFilesPerOwner");
+  if (smallFilesPerOwner) {
+    new Chart(smallFilesPerOwner, {
+      type: "bar",
+      data: smallFilesPerOwnerData,
+      options: smallFilesPerOwnerOptions,
+    });
+  }
+
+  let largeSizePerOwnerOptions = {
     responsive: true,
     indexAxis: 'y',
     plugins: {
       title: {
         display: true,
-        text: "Size of files per owner",
+        text: "Size of files per owner (1,000,000+ files)",
         padding: { top: 10, bottom: 30 },
       },
     },
   };
-  let sizePerOwnerData = {
-    labels: owners,
+  let largeSizePerOwnerData = {
+    labels: largeOwners,
     datasets: [
       {
         label: 'Total size',
-        data: totalSize,
+        data: largeTotalSize,
         backgroundColor: colors[1],
       },
     ],
   };
-  let sizePerOwner = $("#sizePerOwner");
-  if (sizePerOwner) {
-    new Chart(sizePerOwner, {
+  let largeSizePerOwner = $("#largeSizePerOwner");
+  if (largeSizePerOwner) {
+    new Chart(largeSizePerOwner, {
       type: "bar",
-      data: sizePerOwnerData,
-      options: sizePerOwnerOptions,
+      data: largeSizePerOwnerData,
+      options: largeSizePerOwnerOptions,
     });
   }
 
-
-  let perOwnerOptions = {
+  let mediumSizePerOwnerOptions = {
     responsive: true,
     indexAxis: 'y',
     plugins: {
       title: {
         display: true,
-        text: "Statistics per owner",
+        text: "Size of files per owner (100,000 - 999,000 files)",
         padding: { top: 10, bottom: 30 },
       },
     },
   };
-  let perOwnerData = {
-    labels: owners,
+  let mediumSizePerOwnerData = {
+    labels: mediumOwners,
     datasets: [
       {
-        label: 'Total files',
-        data: totalFiles,
-        backgroundColor: colors[2],
-      },{
         label: 'Total size',
-        data: totalSize,
-        backgroundColor: colors[5],
-      }
+        data: mediumTotalSize,
+        backgroundColor: colors[1],
+      },
     ],
   };
-  let perOwner = $("#combinedPerOwner");
-  if (perOwner) {
-    new Chart(perOwner, {
+  let mediumSizePerOwner = $("#mediumSizePerOwner");
+  if (mediumSizePerOwner) {
+    new Chart(mediumSizePerOwner, {
       type: "bar",
-      data: perOwnerData,
-      options: perOwnerOptions,
+      data: mediumSizePerOwnerData,
+      options: mediumSizePerOwnerOptions,
+    });
+  }  
+
+  let smallSizePerOwnerOptions = {
+    responsive: true,
+    indexAxis: 'y',
+    plugins: {
+      title: {
+        display: true,
+        text: "Size of files per owner (less than 100,000 files)",
+        padding: { top: 10, bottom: 30 },
+      },
+    },
+  };
+  let smallSizePerOwnerData = {
+    labels: smallOwners,
+    datasets: [
+      {
+        label: 'Total size',
+        data: smallTotalSize,
+        backgroundColor: colors[1],
+      },
+    ],
+  };
+  let smallSizePerOwner = $("#smallSizePerOwner");
+  if (smallSizePerOwner) {
+    new Chart(smallSizePerOwner, {
+      type: "bar",
+      data: smallSizePerOwnerData,
+      options: smallSizePerOwnerOptions,
     });
   }
 });

--- a/app/templates/databoard.html
+++ b/app/templates/databoard.html
@@ -24,17 +24,34 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col">
-      <canvas id="filesPerOwner"></canvas>
-    </div>
-    <div class="col">
-      <canvas id="sizePerOwner"></canvas>
+      <canvas id="largeFilesPerOwner"></canvas>
     </div>
   </div>
   <div class="row">
     <div class="col">
-      <canvas id="combinedPerOwner"></canvas>
+      <canvas id="mediumFilesPerOwner"></canvas>
     </div>
   </div>
+  <div class="row">
+    <div class="col">
+      <canvas id="smallFilesPerOwner"></canvas>
+    </div> 
+  </div> 
+  <div class="row"></div>
+    <div class="col">
+      <canvas id="largeSizePerOwner"></canvas>
+    </div>
+  </div>
+  <div class="row"></div>
+    <div class="col">
+      <canvas id="mediumSizePerOwner"></canvas>
+    </div>
+  </div>
+  <div class="row"></div>
+    <div class="col">
+      <canvas id="smallSizePerOwner"></canvas>
+    </div>
+  </div>  
 </div>
 
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,6 +12,7 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.0/dist/chart.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
     {% block chart_js %}{% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ version: '3.8'
 services:
 
   databoard-ui:
-    image: registry.lts.harvard.edu/lts/databoard-ui:0.0.3
+    image: registry.lts.harvard.edu/lts/databoard-ui:0.0.4
     build:
       context: .
       dockerfile: DockerfilePub


### PR DESCRIPTION
**Broke it down into large, medium, small item charts.**
* * *

**JIRA Ticket**: [LIBDRS-7986](https://jira.huit.harvard.edu/browse/LIBDRS-7986)

# What does this Pull Request do?
Using new production data from Chris the charts became unreadable because there were too many owners and the difference between files and sizes of the owners was extremely large. This updates the databoard page to show 3 files charts and 3 size charts. 

1. owners with over 1,000,000 files
2. owners with 100,000 - 999,999 files
3. owners with less than 100,000 files.

A description of what steps someone could take to:
* Pull in the code from the `prod-data` branch
* Put [this JSON file](https://jira.huit.harvard.edu/secure/attachment/133849/files_per_owner-1.json) in the `/app/static/files` folder and make sure it is named `files_per_owner.json`.
* Rebuild the container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @mferrarini 